### PR TITLE
Notifications now expire after 2 days not 10 minutes

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -253,13 +253,14 @@ function pushNotificationPayloadToRedis(sessionId, payload) {
 					queuedNotifications = JSON.parse(reply);
 					// don't put notifications back that have expired
 					queuedNotifications = queuedNotifications.filter(function(a) {
-						return a.time >= now - 600000;
+						return a.time >= now - 172800000;
 					});
 				}
 				queuedNotifications.push(data);
 			}
-
-			redisClientNotifications.set(key, JSON.stringify(queuedNotifications), "EX", 600, function(err, res) {
+			// expire in 2 days. Chrome appears to still send push events when devices which were offline come back online
+			// presuming most people will use their device within 2 days
+			redisClientNotifications.set(key, JSON.stringify(queuedNotifications), "EX", 172800, function(err, res) {
 				if (err || res !== "OK") {
 					console.log("Error pushing notification payload to redis.");
 					reject();
@@ -276,7 +277,7 @@ function pushNotificationPayloadToRedis(sessionId, payload) {
 function sendGooglePushNotification(endpoint, payload) {
 	var registrationId = endpoint.url.split('/').pop();
 	console.log('Making request to google push endpoint.');
-    return new Promise(function(resolve) {
+	return new Promise(function(resolve) {
 		request({
 			uri: "https://android.googleapis.com/gcm/send",
 			method: "POST",


### PR DESCRIPTION
Google appears to still send push notifications when devices which were offline at the time come back online.
